### PR TITLE
Corrected the pip package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-> pip install tagg-python
+> pip install tagg
 ```
 
 ## Usage


### PR DESCRIPTION
`tagg-python` is nowhere to be found.
